### PR TITLE
Add eta template for citation format

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -2223,7 +2223,7 @@ echo "$*"</string>
 				<key>fixedorder</key>
 				<false/>
 				<key>items</key>
-				<string>[{"title":"Pandoc","arg":"pandoc","subtitle":"[@citekey, p. 42]"},{"title":"Multi-Markdown (MMD)","arg":"multi-markdown","subtitle":"[42][#citekey]"},{"title":"Latex","arg":"latex","subtitle":"\\cite{citekey}    ℹ️ page numbers not working yet"},{"title":"Wikilink","arg":"wikilink","subtitle":"[[citekey]]         ℹ️ page number will become alias"},{"title":"Tag","arg":"tag","subtitle":"#citekey"},{"title":"Bare Citekey","arg":"bare citekey","subtitle":"citekey"},{"title":"Custom","arg":"custom","subtitle":"🌐 Opens Browser Window with information"}]</string>
+				<string>[{"title":"Pandoc","arg":"pandoc","subtitle":"[@citekey, p. 42]"},{"title":"Multi-Markdown (MMD)","arg":"multi-markdown","subtitle":"[42][#citekey]"},{"title":"Latex","arg":"latex","subtitle":"\\cite{citekey}    ℹ️ page numbers not working yet"},{"title":"Wikilink","arg":"wikilink","subtitle":"[[citekey]]         ℹ️ page number will become alias"},{"title":"Tag","arg":"tag","subtitle":"#citekey"},{"title":"Bare Citekey","arg":"bare citekey","subtitle":"citekey"},{"title":"Eta template","arg":"eta","subtitle":"{% cite citekey %}"},{"title":"Custom","arg":"custom","subtitle":"🌐 Opens Browser Window with information"}]</string>
 				<key>matchmode</key>
 				<integer>0</integer>
 				<key>runningsubtext</key>

--- a/scripts/toggle-citation-format.js
+++ b/scripts/toggle-citation-format.js
@@ -76,6 +76,16 @@ function run(argv) {
 			setEnvVar("_format_page_prefix", ", ");
 			setEnvVar("_format_page_suffix", "");
 			break;
+		case "eta":
+			setEnvVar("_format_citation_start", "{% cite ");
+			setEnvVar("_format_citation_end", " --prefix %}");
+			setEnvVar("_format_citekey_delimiter", "; ");
+			setEnvVar("_format_citekey_prefix", "");
+			setEnvVar("_format_citekey_suffix", "");
+			setEnvVar("_format_page_before_citekey", "false");
+			setEnvVar("_format_page_prefix", ", p. ");
+			setEnvVar("_format_page_suffix", "");
+			break;
 		case "custom":
 			app.openLocation("https://github.com/chrisgrieser/alfred-bibtex-citation-picker/blob/main/README.md#further-format-customization");
 			break;


### PR DESCRIPTION
Hi, I love your workflow for Zotero citation export. 

I use the workflow to export the citation for website post markdown file. The website is powered by Jekyll with kramdown. The standard citekey format `[@citekey]` does not work. I find that to customise the template to `{% cite citekey %}` or `{% cite citekey --prefix %}` can work perfect. I modify the code on the previous version, but it disappeared after I update the workflow file.

May I know whether you can add these code to your workflow?

Many thanks!
Jiaxin