### PR TITLE
added the goto flag to vscode case

### DIFF
--- a/scripts/open-entry.sh
+++ b/scripts/open-entry.sh
@@ -12,7 +12,7 @@ elif [[ "$open_entries_in" == "Sublime" ]]; then
 	# using full path ensures this work even if `subl` hasn't been added to PATH
 	"/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl" "$LIBRARY:$LINE_NO"
 elif [[ "$open_entries_in" == "VS Code" ]]; then
-	code "$LIBRARY:$LINE_NO"
+	code -g "$LIBRARY:$LINE_NO"
 elif [[ "$open_entries_in" == "neovim & alacritty" ]]; then
 	alacritty --command nvim +$LINE_NO "$LIBRARY"
 elif [[ "$open_entries_in" == "Zotero" ]]; then


### PR DESCRIPTION
 -g --goto <file:line[:character]>          Open a file at the path on the specified line and character position.