### PR TITLE
Add citation format for iA Writer

### DIFF
--- a/scripts/toggle-citation-format.js
+++ b/scripts/toggle-citation-format.js
@@ -86,6 +86,16 @@ function run(argv) {
 			setEnvVar("_format_page_prefix", ", p. ");
 			setEnvVar("_format_page_suffix", "");
 			break;
+		case "iA":
+			setEnvVar("_format_citation_start", "[");
+			setEnvVar("_format_citation_end", "]");
+			setEnvVar("_format_citekey_delimiter", "; ");
+			setEnvVar("_format_citekey_prefix", "^");
+			setEnvVar("_format_citekey_suffix", "");
+			setEnvVar("_format_page_before_citekey", "false");
+			setEnvVar("_format_page_prefix", ", p. ");
+			setEnvVar("_format_page_suffix", "");
+			break;
 		case "custom":
 			app.openLocation("https://github.com/chrisgrieser/alfred-bibtex-citation-picker/blob/main/README.md#further-format-customization");
 			break;


### PR DESCRIPTION
Hi!

iA Writer uses a different syntax for inline citations in its markdown dialect [1]. By adding this citation style, this workflow essentially adds Zotero support to iA Writer. However, I believe that iA Writer does not support multiple citations within one inline citation, so '_format_citekey_delimiter' will not be supported.

What do you think?

[1]: https://ia.net/writer/support/general/markdown-guide#footnotes