### PR TITLE
Create a new bibliography copy styple

### DIFF
--- a/scripts/generate_temporary_citation.sh
+++ b/scripts/generate_temporary_citation.sh
@@ -1,0 +1,30 @@
+#!/bin/zsh
+# shellcheck disable=SC2154
+export PATH=/usr/local/bin:/opt/homebrew/bin/:$PATH
+
+CSL=apa-6th-edition.csl
+CITEKEY="@$*" # citekey with @ prefix for pandoc
+LIBRARY="${bibtex_library_path/#\~/$HOME}"
+DUMMYDOC=$(cat <<EOF
+---
+suppress-bibliography: true
+---
+$CITEKEY
+EOF
+)
+
+if ! command -v pandoc &>/dev/null; then
+	echo -n "You need to install pandoc for this feature." | pbcopy
+else
+	echo "$DUMMYDOC" \
+		| pandoc --citeproc --read=markdown --write=plain --csl="$CSL" --bibliography="$LIBRARY" \
+		| tr "\n" " " \
+		| tr -s " " \
+		| sed -E "s/^ //" \
+		| sed -E "s/ $//" \
+		| pbcopy
+fi
+
+# paste
+sleep 0.2
+osascript -e 'tell application "System Events" to keystroke "v" using {command down}'


### PR DESCRIPTION
Hi,

I follow your `generate_temp_bib.sh` to create a new style that only generates the inline citations. 
In `generate_temp_bib.sh`, if you press the button `cmd+option+enter`, it will return:
```
Wang, Z., Chen, J., & Zhao, X. (2020). Risk Information Disclosure and Bank Soundness: Does Regulation Matter? Evidence from China*. International Review of Finance, 20(4), 973–981. https://doi.org/10.1111/irfi.12244
```

In `generate_temp_citation.sh`, it will return:
```
Wang, Chen, & Zhao (2020)
```

You may assign another hotkey combination for this citation style. 
